### PR TITLE
2.5.0 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 
-2.4.1
+2.5.0 (2021-09-20)
 ++++++++++++++++++
 
 * Previously, the ``py.typed`` file was not being added to the source

--- a/minfraud/version.py
+++ b/minfraud/version.py
@@ -1,2 +1,2 @@
 """Internal module for version (to prevent cyclic imports)"""
-__version__ = "2.4.0"
+__version__ = "2.5.0"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with io.open("README.rst", "r", encoding="utf-8") as f:
 requirements = [
     "aiohttp>=3.6.2,<4.0.0",
     "email_validator>=1.1.1,<2.0.0",
-    "geoip2>=4.1.0,<5.0.0",
+    "geoip2>=4.3.0,<5.0.0",
     "requests>=2.24.0,<3.0.0",
     "urllib3>=1.25.2,<2.0.0",
     "voluptuous",


### PR DESCRIPTION
- Require new version of geoip2
- Set release date
- Update for v2.5.0
