### PR TITLE
Add support for 8 digit IINs and 2 digit last_digits

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,10 +28,16 @@ History
   ``last_digits``/``last_4_digits`` also now supports two digit values in
   addition to the previous four digit values.
 * Eight digit ``/credit_card/issuer_id_number`` inputs are now supported in
-  addition to the previously accepted six digit ``issuer_id_number``. If you
-  send six digits for the ``issuer_id_number``, you should send the last four
-  digits for ``last_digits``. If you send eight digits for ``issuer_id_number``
-  you should send the last two digits for ``last_digits``.
+  addition to the previously accepted six digit ``issuer_id_number``. In most
+  cases, you should send the last four digits for ``last_digits``. If you send
+  an ``issuer_id_number`` that contains an eight digit IIN, and if the credit
+  card brand is not one of the following, you should send the last two digits
+  for ``last_digits``:
+  * ``Discover``
+  * ``JCB``
+  * ``Mastercard``
+  * ``UnionPay``
+  * ``Visa``
 
 2.5.0 (2021-09-20)
 ++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,15 @@ History
   * ``payvision``
   * ``trustly``
   * ``windcave``
+* The ``/credit_card/last_4_digits`` input has been deprecated in favor of
+  ``/credit_card/last_digits`` and will be removed in a future release.
+  ``last_digits``/``last_4_digits`` also now supports two digit values in
+  addition to the previous four digit values.
+* Eight digit ``/credit_card/issuer_id_number`` inputs are now supported in
+  addition to the previously accepted six digit ``issuer_id_number``. If you
+  send six digits for the ``issuer_id_number``, you should send the last four
+  digits for ``last_digits``. If you send eight digits for ``issuer_id_number``
+  you should send the last two digits for ``last_digits``.
 
 2.5.0 (2021-09-20)
 ++++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -191,10 +191,10 @@ Score, Insights and Factors Example
     >>>         'bank_phone_country_code': '1',
     >>>         'avs_result': 'Y',
     >>>         'bank_phone_number': '123-456-1234',
-    >>>         'last_4_digits': '7643',
+    >>>         'last_digits': '7643',
     >>>         'cvv_result': 'N',
     >>>         'bank_name': 'Bank of No Hope',
-    >>>         'issuer_id_number': '411111'
+    >>>         'issuer_id_number': '411111',
     >>>         'was_3d_secure_successful': True
     >>>     },
     >>>     'payment': {

--- a/minfraud/request.py
+++ b/minfraud/request.py
@@ -69,15 +69,15 @@ def _copy_and_clean(data: Any) -> Any:
     return data
 
 
-def clean_credit_card(transaction):
+def clean_credit_card(credit_card):
     """Clean the credit_card input of a transaction request"""
-    last4 = transaction["credit_card"].pop("last_4_digits", None)
+    last4 = credit_card.pop("last_4_digits", None)
     if last4:
         warnings.warn(
             "last_4_digits has been deprecated in favor of last_digits",
             DeprecationWarning,
         )
-        transaction["credit_card"]["last_digits"] = last4
+        credit_card["last_digits"] = last4
 
 
 def maybe_hash_email(transaction):

--- a/minfraud/request.py
+++ b/minfraud/request.py
@@ -5,6 +5,7 @@ that may break any direct use of it.
 
 """
 
+import warnings
 import hashlib
 from typing import Any, Dict
 from voluptuous import MultipleInvalid
@@ -53,6 +54,9 @@ def prepare_transaction(
     if hash_email:
         maybe_hash_email(cleaned_request)
 
+    if cleaned_request.get("credit_card", None):
+        clean_credit_card(cleaned_request)
+
     return cleaned_request
 
 
@@ -63,6 +67,17 @@ def _copy_and_clean(data: Any) -> Any:
     if isinstance(data, (list, set, tuple)):
         return [_copy_and_clean(x) for x in data if x is not None]
     return data
+
+
+def clean_credit_card(transaction):
+    """Clean the credit_card input of a transaction request"""
+    last4 = transaction["credit_card"].pop("last_4_digits", None)
+    if last4:
+        warnings.warn(
+            "last_4_digits has been deprecated in favor of last_digits",
+            DeprecationWarning,
+        )
+        transaction["credit_card"]["last_digits"] = last4
 
 
 def maybe_hash_email(transaction):

--- a/minfraud/validation.py
+++ b/minfraud/validation.py
@@ -291,18 +291,14 @@ def _uri(s: str) -> str:
     return s
 
 
-def _validate_last_digits(req):
-    cc = req.get("credit_card")
-    if cc is None:
-        return
-
-    iin = cc.get("issuer_id_number")
+def _validate_last_digits(cc):
+    iin = cc.get("issuer_id_number", None)
     if iin is None:
         return
 
     if iin and len(iin) == 8:
-        last_digits = cc.get("last_digits")
-        last_4_digits = cc.get("last_4_digits")
+        last_digits = cc.get("last_digits", None)
+        last_4_digits = cc.get("last_4_digits", None)
         if last_digits and len(last_digits) != 2:
             raise LengthInvalid(
                 "last_digits must be two digits when the issuer_id_number is eight digits."
@@ -315,19 +311,19 @@ def _validate_last_digits(req):
 
 
 validate_transaction = Schema(
-    All(
-        {
-            "account": {
-                "user_id": str,
-                "username_md5": _md5,
-            },
-            "billing": _address,
-            "payment": {
-                "processor": _payment_processor,
-                "was_authorized": bool,
-                "decline_code": str,
-            },
-            "credit_card": {
+    {
+        "account": {
+            "user_id": str,
+            "username_md5": _md5,
+        },
+        "billing": _address,
+        "payment": {
+            "processor": _payment_processor,
+            "was_authorized": bool,
+            "decline_code": str,
+        },
+        "credit_card": All(
+            {
                 "avs_result": _single_char,
                 "bank_name": str,
                 "bank_phone_country_code": _telephone_country_code,
@@ -339,46 +335,46 @@ validate_transaction = Schema(
                 "token": _credit_card_token,
                 "was_3d_secure_successful": bool,
             },
-            "custom_inputs": {_custom_input_key: _custom_input_value},
-            "device": {
-                "accept_language": str,
-                "ip_address": _ip_address,
-                "session_age": All(_any_number, Range(min=0)),
-                "session_id": str,
-                "user_agent": str,
-            },
-            "email": {
-                "address": _email_or_md5,
-                "domain": _hostname,
-            },
-            "event": {
-                "shop_id": str,
-                "time": _rfc3339_datetime,
-                "type": _event_type,
-                "transaction_id": str,
-            },
-            "order": {
-                "affiliate_id": str,
-                "amount": _price,
-                "currency": _currency_code,
-                "discount_code": str,
-                "has_gift_message": bool,
-                "is_gift": bool,
-                "referrer_uri": _uri,
-                "subaffiliate_id": str,
-            },
-            "shipping": _shipping_address,
-            "shopping_cart": [
-                {
-                    "category": str,
-                    "item_id": str,
-                    "price": _price,
-                    "quantity": All(int, Range(min=1)),
-                },
-            ],
+            _validate_last_digits,
+        ),
+        "custom_inputs": {_custom_input_key: _custom_input_value},
+        "device": {
+            "accept_language": str,
+            "ip_address": _ip_address,
+            "session_age": All(_any_number, Range(min=0)),
+            "session_id": str,
+            "user_agent": str,
         },
-        _validate_last_digits,
-    )
+        "email": {
+            "address": _email_or_md5,
+            "domain": _hostname,
+        },
+        "event": {
+            "shop_id": str,
+            "time": _rfc3339_datetime,
+            "type": _event_type,
+            "transaction_id": str,
+        },
+        "order": {
+            "affiliate_id": str,
+            "amount": _price,
+            "currency": _currency_code,
+            "discount_code": str,
+            "has_gift_message": bool,
+            "is_gift": bool,
+            "referrer_uri": _uri,
+            "subaffiliate_id": str,
+        },
+        "shipping": _shipping_address,
+        "shopping_cart": [
+            {
+                "category": str,
+                "item_id": str,
+                "price": _price,
+                "quantity": All(int, Range(min=1)),
+            },
+        ],
+    },
 )
 
 

--- a/minfraud/validation.py
+++ b/minfraud/validation.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from email_validator import validate_email  # type: ignore
 from voluptuous import All, Any, In, Match, Range, Required, Schema
-from voluptuous.error import LengthInvalid, UrlInvalid
+from voluptuous.error import UrlInvalid
 
 # Pylint doesn't like the private function type naming for the callable
 # objects below. Given the consistent use of them, the current names seem
@@ -291,25 +291,6 @@ def _uri(s: str) -> str:
     return s
 
 
-def _validate_last_digits(cc):
-    iin = cc.get("issuer_id_number", None)
-    if iin is None:
-        return
-
-    if iin and len(iin) == 8:
-        last_digits = cc.get("last_digits", None)
-        last_4_digits = cc.get("last_4_digits", None)
-        if last_digits and len(last_digits) != 2:
-            raise LengthInvalid(
-                "last_digits must be two digits when the issuer_id_number is eight digits."
-            )
-        if last_4_digits and len(last_4_digits) != 2:
-            raise LengthInvalid(
-                "last_4_digits must be two digits when the issuer_id_number is eight digits."
-            )
-    return
-
-
 validate_transaction = Schema(
     {
         "account": {
@@ -322,21 +303,18 @@ validate_transaction = Schema(
             "was_authorized": bool,
             "decline_code": str,
         },
-        "credit_card": All(
-            {
-                "avs_result": _single_char,
-                "bank_name": str,
-                "bank_phone_country_code": _telephone_country_code,
-                "bank_phone_number": str,
-                "cvv_result": _single_char,
-                "issuer_id_number": _iin,
-                "last_digits": _credit_card_last_digits,
-                "last_4_digits": _credit_card_last_digits,
-                "token": _credit_card_token,
-                "was_3d_secure_successful": bool,
-            },
-            _validate_last_digits,
-        ),
+        "credit_card": {
+            "avs_result": _single_char,
+            "bank_name": str,
+            "bank_phone_country_code": _telephone_country_code,
+            "bank_phone_number": str,
+            "cvv_result": _single_char,
+            "issuer_id_number": _iin,
+            "last_digits": _credit_card_last_digits,
+            "last_4_digits": _credit_card_last_digits,
+            "token": _credit_card_token,
+            "was_3d_secure_successful": bool,
+        },
         "custom_inputs": {_custom_input_key: _custom_input_value},
         "device": {
             "accept_language": str,

--- a/tests/data/full-transaction-request.json
+++ b/tests/data/full-transaction-request.json
@@ -47,7 +47,7 @@
   },
   "credit_card": {
     "issuer_id_number": "411111",
-    "last_4_digits": "7643",
+    "last_digits": "7643",
     "bank_name": "Bank of No Hope",
     "bank_phone_country_code": "1",
     "bank_phone_number": "123-456-1234",

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,6 +1,6 @@
 import unittest
 
-from minfraud.request import maybe_hash_email
+from minfraud.request import maybe_hash_email, clean_credit_card
 
 
 class TestRequest(unittest.TestCase):
@@ -144,5 +144,85 @@ class TestRequest(unittest.TestCase):
                 transaction = test["input"]
 
                 maybe_hash_email(transaction)
+
+                self.assertEqual(test["expected"], transaction)
+
+    def test_clean_credit_card(self):
+        tests = [
+            {
+                "name": "deprecated last_4_digits is cleaned to last_digits",
+                "input": {
+                    "credit_card": {
+                        "issuer_id_number": "123456",
+                        "last_4_digits": "1234",
+                    },
+                    "device": {"ip_address": "1.1.1.1"},
+                },
+                "expected": {
+                    "credit_card": {
+                        "issuer_id_number": "123456",
+                        "last_digits": "1234",
+                    },
+                    "device": {"ip_address": "1.1.1.1"},
+                },
+            },
+            {
+                "name": "6 digit iin, 4 digit last_digits",
+                "input": {
+                    "credit_card": {
+                        "issuer_id_number": "123456",
+                        "last_digits": "1234",
+                    },
+                    "device": {"ip_address": "1.1.1.1"},
+                },
+                "expected": {
+                    "credit_card": {
+                        "issuer_id_number": "123456",
+                        "last_digits": "1234",
+                    },
+                    "device": {"ip_address": "1.1.1.1"},
+                },
+            },
+            {
+                "name": "8 digit iin, 2 digit last_digits",
+                "input": {
+                    "credit_card": {
+                        "issuer_id_number": "12345678",
+                        "last_digits": "34",
+                    },
+                    "device": {"ip_address": "1.1.1.1"},
+                },
+                "expected": {
+                    "credit_card": {
+                        "issuer_id_number": "12345678",
+                        "last_digits": "34",
+                    },
+                    "device": {"ip_address": "1.1.1.1"},
+                },
+            },
+            {
+                "name": "8 digit iin, 4 digit last_digits",
+                "input": {
+                    "credit_card": {
+                        "issuer_id_number": "12345678",
+                        "last_digits": "1234",
+                    },
+                    "device": {"ip_address": "1.1.1.1"},
+                },
+                "expected": {
+                    "credit_card": {
+                        "issuer_id_number": "12345678",
+                        "last_digits": "1234",
+                    },
+                    "device": {"ip_address": "1.1.1.1"},
+                },
+            },
+        ]
+
+        for test in tests:
+            with self.subTest(test["name"]):
+                transaction = test["input"]
+
+                clean_credit_card(transaction)
 
                 self.assertEqual(test["expected"], transaction)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -152,69 +152,34 @@ class TestRequest(unittest.TestCase):
             {
                 "name": "deprecated last_4_digits is cleaned to last_digits",
                 "input": {
-                    "credit_card": {
-                        "issuer_id_number": "123456",
-                        "last_4_digits": "1234",
-                    },
-                    "device": {"ip_address": "1.1.1.1"},
+                    "issuer_id_number": "123456",
+                    "last_4_digits": "1234",
                 },
                 "expected": {
-                    "credit_card": {
-                        "issuer_id_number": "123456",
-                        "last_digits": "1234",
-                    },
-                    "device": {"ip_address": "1.1.1.1"},
+                    "issuer_id_number": "123456",
+                    "last_digits": "1234",
                 },
             },
             {
                 "name": "6 digit iin, 4 digit last_digits",
                 "input": {
-                    "credit_card": {
-                        "issuer_id_number": "123456",
-                        "last_digits": "1234",
-                    },
-                    "device": {"ip_address": "1.1.1.1"},
+                    "issuer_id_number": "123456",
+                    "last_digits": "1234",
                 },
                 "expected": {
-                    "credit_card": {
-                        "issuer_id_number": "123456",
-                        "last_digits": "1234",
-                    },
-                    "device": {"ip_address": "1.1.1.1"},
+                    "issuer_id_number": "123456",
+                    "last_digits": "1234",
                 },
             },
             {
                 "name": "8 digit iin, 2 digit last_digits",
                 "input": {
-                    "credit_card": {
-                        "issuer_id_number": "12345678",
-                        "last_digits": "34",
-                    },
-                    "device": {"ip_address": "1.1.1.1"},
+                    "issuer_id_number": "12345678",
+                    "last_digits": "34",
                 },
                 "expected": {
-                    "credit_card": {
-                        "issuer_id_number": "12345678",
-                        "last_digits": "34",
-                    },
-                    "device": {"ip_address": "1.1.1.1"},
-                },
-            },
-            {
-                "name": "8 digit iin, 4 digit last_digits",
-                "input": {
-                    "credit_card": {
-                        "issuer_id_number": "12345678",
-                        "last_digits": "1234",
-                    },
-                    "device": {"ip_address": "1.1.1.1"},
-                },
-                "expected": {
-                    "credit_card": {
-                        "issuer_id_number": "12345678",
-                        "last_digits": "1234",
-                    },
-                    "device": {"ip_address": "1.1.1.1"},
+                    "issuer_id_number": "12345678",
+                    "last_digits": "34",
                 },
             },
         ]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -158,7 +158,7 @@ class TestCreditCard(ValidationBase, unittest.TestCase):
         self.check_transaction(
             {"credit_card": {"issuer_id_number": "88888888", "last_digits": "12"}}
         )
-        self.check_invalid_transaction(
+        self.check_transaction(
             {"credit_card": {"issuer_id_number": "88888888", "last_digits": "1234"}}
         )
         self.check_transaction(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -143,16 +143,34 @@ class TestShippingAddress(unittest.TestCase, AddressBase):
 
 class TestCreditCard(ValidationBase, unittest.TestCase):
     def test_issuer_id_number(self):
-        for iin in ("123456", "532313"):
+        for iin in ("123456", "532313", "88888888"):
             self.check_transaction({"credit_card": {"issuer_id_number": iin}})
         for invalid in ("12345", "1234567", 123456, "12345a"):
             self.check_invalid_transaction(
                 {"credit_card": {"issuer_id_number": invalid}}
             )
 
+    def test_last_digits(self):
+        for last_digits in ("1234", "9323", "34"):
+            self.check_transaction({"credit_card": {"last_digits": last_digits}})
+        for invalid in ("12345", "123", 1234, "123a"):
+            self.check_invalid_transaction({"credit_card": {"last_digits": invalid}})
+        self.check_transaction(
+            {"credit_card": {"issuer_id_number": "88888888", "last_digits": "12"}}
+        )
+        self.check_invalid_transaction(
+            {"credit_card": {"issuer_id_number": "88888888", "last_digits": "1234"}}
+        )
+        self.check_transaction(
+            {"credit_card": {"issuer_id_number": "666666", "last_digits": "1234"}}
+        )
+        self.check_transaction(
+            {"credit_card": {"issuer_id_number": "666666", "last_digits": "34"}}
+        )
+
     def test_last_4_digits(self):
-        for iin in ("1234", "9323"):
-            self.check_transaction({"credit_card": {"last_4_digits": iin}})
+        for last_digits in ("1234", "9323", "34"):
+            self.check_transaction({"credit_card": {"last_4_digits": last_digits}})
         for invalid in ("12345", "123", 1234, "123a"):
             self.check_invalid_transaction({"credit_card": {"last_4_digits": invalid}})
 


### PR DESCRIPTION
Previously issuer_id_number was expected to be 6 digits and
last_4_digits to be 4 digits. This changes the validation to
additionally allow for 8 digit issuer_id_numbers and 2 digit
last_4_digits.

Additionally last_4_digits has been deprecated in favor of the
more appropriately named last_digits.