### PR TITLE
Remove bad-continuation pylint config

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable=bad-continuation,too-few-public-methods,too-many-arguments
+disable=too-few-public-methods,too-many-arguments
 
 [BASIC]
 


### PR DESCRIPTION
This lint has been removed from pylint.
