### PR TITLE
Release 3.12

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,11 +3,15 @@
 History
 -------
 
-2.9.0
+2.9.0 (2023-12-05)
 ++++++++++++++++++
 
 * IMPORTANT: Python 3.8 or greater is required. If you are using an older
   version, please use an earlier release.
+* Updated ``geoip2`` to version that includes the ``is_anycast`` attribute on
+  ``geoip2.record.Traits``. This property is ``True`` if the IP address
+  belongs to an `anycast network <https://en.wikipedia.org/wiki/Anycast>`_.
+  This is available in minFraud Insights and Factors.
 
 2.8.0 (2023-05-09)
 ++++++++++++++++++

--- a/minfraud/version.py
+++ b/minfraud/version.py
@@ -1,2 +1,2 @@
 """Internal module for version (to prevent cyclic imports)"""
-__version__ = "2.8.0"
+__version__ = "2.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "minfraud"
-version = "2.8.0"
+version = "2.9.0"
 description = "MaxMind minFraud Score, Insights, Factors and Report Transactions API"
 authors = [
     {name = "Gregory Oschwald", email = "goschwald@maxmind.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "setuptools>=60.0.0",
     "aiohttp>=3.6.2,<4.0.0",
     "email_validator>=2.0.0,<3.0.0",
-    "geoip2>=4.7.0,<5.0.0",
+    "geoip2>=4.8.0,<5.0.0",
     "requests>=2.24.0,<3.0.0",
     "voluptuous",
 ]


### PR DESCRIPTION
- List 3.12 as supported and test on it
- Require Python 3.8
- Work around mindflayer/python-mocket#209
- Fix deprecation warning from email_validator
- Upgrade geoip2
- Update for v2.9.0
