### PR TITLE
Use HTTPS in tests again

### DIFF
--- a/minfraud/webservice.py
+++ b/minfraud/webservice.py
@@ -32,10 +32,6 @@ _AIOHTTP_UA = f"minFraud-API/{__version__} {aiohttp.http.SERVER_SOFTWARE}"
 
 _REQUEST_UA = f"minFraud-API/{__version__} {requests.utils.default_user_agent()}"
 
-# We have this so that we can avoid a mocket issue:
-# https://github.com/mindflayer/python-mocket/issues/209
-_SCHEME = "https"
-
 
 # pylint: disable=too-many-instance-attributes, missing-class-docstring
 class BaseClient:
@@ -62,7 +58,7 @@ class BaseClient:
         self._license_key = license_key
         self._timeout = timeout
 
-        base_uri = f"{_SCHEME}://{host}/minfraud/v2.0"
+        base_uri = f"https://{host}/minfraud/v2.0"
         self._score_uri = "/".join([base_uri, "score"])
         self._insights_uri = "/".join([base_uri, "insights"])
         self._factors_uri = "/".join([base_uri, "factors"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "mocket>=3.11.1",
+    "mocket>=3.12.3",
 ]
 
 [tool.setuptools.package-data]

--- a/tests/test_webservice.py
+++ b/tests/test_webservice.py
@@ -19,12 +19,7 @@ from minfraud.errors import (
 from minfraud.models import Factors, Insights, Score
 from minfraud.webservice import AsyncClient, Client
 
-import minfraud.webservice
 import unittest
-
-# We have this so that we can avoid a mocket issue:
-# https://github.com/mindflayer/python-mocket/issues/209
-minfraud.webservice._SCHEME = "http"
 
 
 class BaseTest(unittest.TestCase):
@@ -41,7 +36,7 @@ class BaseTest(unittest.TestCase):
         with open(os.path.join(test_dir, self.response_file), encoding="utf-8") as file:
             self.response = file.read()
 
-    base_uri = "http://minfraud.maxmind.com/minfraud/v2.0"
+    base_uri = "https://minfraud.maxmind.com/minfraud/v2.0"
 
     @httprettified
     def test_invalid_auth(self):


### PR DESCRIPTION
mocket 3.12.3 fixes an interaction with aiohttp that prevented HTTPS
from working with it.
