### PR TITLE
Add `clear` to the valid tag values (STF-190)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ History
   linking.
 * Added ``banquest``, ``fat_zebra``, ``summit_payments``, and ``yaadpay`` to
   the ``/payment/processor`` validation.
+* Added ``clear`` to the valid values for the ``tag`` parameter on the
+  Report Transaction API.
 * The version is now retrieved from package metadata at runtime using
   ``importlib.metadata``. This reduces the chance of version inconsistencies
   during releases.

--- a/src/minfraud/validation.py
+++ b/src/minfraud/validation.py
@@ -408,7 +408,7 @@ def _maxmind_id(s: str | None) -> str:
     raise ValueError
 
 
-_tag = In(["chargeback", "not_fraud", "spam_or_abuse", "suspected_fraud"])
+_tag = In(["chargeback", "clear", "not_fraud", "spam_or_abuse", "suspected_fraud"])
 
 
 def _uuid(s: str) -> str:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -470,7 +470,13 @@ class TestReport(ValidationBase):
             self.check_report_str_type(key)
 
     def test_tag(self) -> None:
-        for good in ("chargeback", "not_fraud", "spam_or_abuse", "suspected_fraud"):
+        for good in (
+            "chargeback",
+            "clear",
+            "not_fraud",
+            "spam_or_abuse",
+            "suspected_fraud",
+        ):
             self.check_report({"tag": good})
         for bad in ("risky_business", "", None):
             self.check_invalid_report({"tag": bad})


### PR DESCRIPTION
## Summary

- Adds `clear` to the `_tag` validator in `src/minfraud/validation.py` so the
  Report Transaction API accepts the new tag.
- Updates `tests/test_validation.py` to cover the new value.
- Adds a HISTORY.rst bullet under the existing unreleased `3.3.0` entry.

The `clear` tag retracts a previously reported fraud report on a transaction
(restoring its label to "unknown", distinct from the positive `not_fraud`
signal). Backend support shipped in STF-15; this adds SDK support per STF-190.

Linear: https://linear.app/maxmind/issue/STF-190

## Test plan

- [x] `uv run pytest tests/test_validation.py` — 62 passed
- [x] `uv run ruff format` / `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)