### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ All response models in `models.py` inherit from `_Serializable` which provides:
 
 **Component Models:**
 - `ScoreIPAddress` - Simple IP risk info for Score
-- `IPAddress` extends `geoip2.models.Insights` - Full GeoIP2 data plus minFraud risk
+- `IPAddress` extends `geoip2.models.Insights` - Full GeoIP data plus minFraud risk
 - `CreditCard`, `Device`, `Email`, `EmailDomain`, `Phone` - Transaction component data
 - `BillingAddress`, `ShippingAddress` - Address information
 - `Disposition` - Custom rules disposition
@@ -148,7 +148,7 @@ minFraud models extend GeoIP2 models:
 - `IPAddress` extends `geoip2.models.Insights` - Adds `risk` and `risk_reasons`
 - `GeoIP2Location` extends `geoip2.records.Location` - Adds `local_time`
 
-This allows minFraud responses to include full GeoIP2 data (city, country, ISP, etc.) alongside fraud data.
+This allows minFraud responses to include full GeoIP data (city, country, ISP, etc.) alongside fraud data.
 
 ## Testing Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,9 @@ Clients handle HTTP status codes:
 - 500-599: Raised as `HTTPError` with status and body
 - Success (200): Response JSON parsed into model objects
 
-#### 7. **GeoIP2 Integration**
+#### 7. **GeoIP Integration**
 
-minFraud models extend GeoIP2 models:
+minFraud models extend GeoIP models:
 - `IPAddress` extends `geoip2.models.Insights` - Adds `risk` and `risk_reasons`
 - `GeoIP2Location` extends `geoip2.records.Location` - Adds `local_time`
 

--- a/src/minfraud/models.py
+++ b/src/minfraud/models.py
@@ -966,7 +966,7 @@ class Factors(_Serializable):
     easily identify a particular request."""
 
     ip_address: IPAddress
-    """A :class:`.IPAddress` object containing GeoIP2 and
+    """A :class:`.IPAddress` object containing GeoIP and
     minFraud Insights information about the IP address."""
 
     queries_remaining: int
@@ -1090,7 +1090,7 @@ class Insights(_Serializable):
     easily identify a particular request."""
 
     ip_address: IPAddress
-    """A :class:`.IPAddress` object containing GeoIP2 and
+    """A :class:`.IPAddress` object containing GeoIP and
     minFraud Insights information about the IP address."""
 
     queries_remaining: int

--- a/src/minfraud/models.py
+++ b/src/minfraud/models.py
@@ -107,7 +107,7 @@ class GeoIP2Location(geoip2.records.Location):
 
 
 class IPAddress(geoip2.models.Insights):
-    """Model for minFraud and GeoIP2 data about the IP address.
+    """Model for minFraud and GeoIP data about the IP address.
 
     This class inherits from :py:class:`geoip2.models.Insights`. In addition
     to the attributes provided by that class, it provides the ``risk`` and


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)