### PR TITLE
Use aiohttp.encode_basic_auth() instead of deprecated BasicAuth

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,10 @@ History
 * The version is now retrieved from package metadata at runtime using
   ``importlib.metadata``. This reduces the chance of version inconsistencies
   during releases.
+* The async client now builds its ``Authorization`` header with
+  ``aiohttp.encode_basic_auth()`` instead of the ``aiohttp.BasicAuth`` /
+  ``auth=`` parameter, which are deprecated as of aiohttp 3.14.0. As a result,
+  the minimum required ``aiohttp`` version is now 3.14.0.
 
 3.2.0 (2025-11-20)
 ++++++++++++++++++

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Gregory Oschwald", email = "goschwald@maxmind.com"},
 ]
 dependencies = [
-    "aiohttp>=3.6.2,<4.0.0",
+    "aiohttp>=3.14.0,<4.0.0",
     "email_validator>=2.0.0,<3.0.0",
     "geoip2>=5.2.0,<6.0.0",
     "requests>=2.24.0,<3.0.0",

--- a/src/minfraud/webservice.py
+++ b/src/minfraud/webservice.py
@@ -442,8 +442,14 @@ class AsyncClient(BaseClient):
     async def _session(self) -> aiohttp.ClientSession:
         if not hasattr(self, "_existing_session"):
             self._existing_session = aiohttp.ClientSession(
-                auth=aiohttp.BasicAuth(self._account_id, self._license_key),
-                headers={"Accept": "application/json", "User-Agent": _AIOHTTP_UA},
+                headers={
+                    "Accept": "application/json",
+                    "Authorization": aiohttp.encode_basic_auth(
+                        self._account_id,
+                        self._license_key,
+                    ),
+                    "User-Agent": _AIOHTTP_UA,
+                },
                 timeout=aiohttp.ClientTimeout(total=self._timeout),
             )
 

--- a/tests/test_webservice.py
+++ b/tests/test_webservice.py
@@ -237,6 +237,17 @@ class BaseTransactionTest(BaseTest):
             self.assertEqual("004", model.ip_address.traits.mobile_network_code)
             self.assertEqual("ANONYMOUS_IP", model.ip_address.risk_reasons[0].code)
 
+    def test_authorization_header(self) -> None:
+        # Credentials must be sent via the Authorization header rather than the
+        # deprecated aiohttp BasicAuth / auth= parameter. The expected value is
+        # base64("42:abcdef123456").
+        self.create_success()
+        request, _ = self.httpserver.log[-1]
+        self.assertEqual(
+            "Basic NDI6YWJjZGVmMTIzNDU2",
+            request.headers.get("Authorization"),
+        )
+
     def test_200_on_request_with_nones(self) -> None:
         model = self.create_success(
             request={

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.6.2,<4.0.0" },
+    { name = "aiohttp", specifier = ">=3.14.0,<4.0.0" },
     { name = "email-validator", specifier = ">=2.0.0,<3.0.0" },
     { name = "geoip2", specifier = ">=5.2.0,<6.0.0" },
     { name = "requests", specifier = ">=2.24.0,<3.0.0" },


### PR DESCRIPTION
## STF-604

As of aiohttp 3.14.0, `aiohttp.BasicAuth` and the `auth=` parameter on `ClientSession` are deprecated and will be removed in aiohttp 4.0, emitting `DeprecationWarning`s in CI. This builds the `Authorization` header explicitly with `aiohttp.encode_basic_auth()` in the async client instead.

Only the async (aiohttp) client is affected; the sync client uses `requests` (`.auth`), which is not deprecated.

### Changes
- Migrate `AsyncClient._session()` to an explicit `Authorization` header.
- Raise the minimum aiohttp version to `>=3.14.0` (where `encode_basic_auth` was introduced).
- Add a webservice test asserting the `Authorization` header is sent, exercised for both the sync and async clients.

### Notes
- `encode_basic_auth()` defaults to utf-8 where `BasicAuth` defaulted to latin1. Irrelevant here (numeric account IDs, ASCII license keys), but worth noting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)