### PR TITLE
Add residential sub-object to anonymizer for Insights

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,12 @@ History
   ``aiohttp.encode_basic_auth()`` instead of the ``aiohttp.BasicAuth`` /
   ``auth=`` parameter, which are deprecated as of aiohttp 3.14.0. As a result,
   the minimum required ``aiohttp`` version is now 3.14.0.
+* The ``ip_address.anonymizer`` object may now contain a ``residential``
+  attribute. This is a ``geoip2.records.AnonymizerFeed`` object containing
+  residential proxy data for the network. It has the following fields:
+  ``confidence``, ``network_last_seen``, and ``provider_name``. It may be
+  populated even when no other ``anonymizer`` attributes are set. This
+  requires ``geoip2`` 5.3.0 or greater.
 
 3.2.0 (2025-11-20)
 ++++++++++++++++++

--- a/tests/data/factors-response.json
+++ b/tests/data/factors-response.json
@@ -28,7 +28,12 @@
       "is_residential_proxy": true,
       "is_tor_exit_node": true,
       "network_last_seen": "2025-01-15",
-      "provider_name": "TestVPN"
+      "provider_name": "TestVPN",
+      "residential": {
+        "confidence": 82,
+        "network_last_seen": "2026-05-11",
+        "provider_name": "quickshift"
+      }
     },
     "city": {
       "confidence": 42,

--- a/tests/data/insights-response.json
+++ b/tests/data/insights-response.json
@@ -28,7 +28,12 @@
       "is_residential_proxy": true,
       "is_tor_exit_node": true,
       "network_last_seen": "2025-01-15",
-      "provider_name": "TestVPN"
+      "provider_name": "TestVPN",
+      "residential": {
+        "confidence": 82,
+        "network_last_seen": "2026-05-11",
+        "provider_name": "quickshift"
+      }
     },
     "city": {
       "confidence": 42,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -197,6 +197,11 @@ class TestModels(unittest.TestCase):
                 "is_tor_exit_node": True,
                 "network_last_seen": "2025-01-15",
                 "provider_name": "TestVPN",
+                "residential": {
+                    "confidence": 82,
+                    "network_last_seen": "2026-05-11",
+                    "provider_name": "quickshift",
+                },
             },
             traits={
                 "is_anonymous": True,
@@ -237,6 +242,14 @@ class TestModels(unittest.TestCase):
             datetime.date(2025, 1, 15), address.anonymizer.network_last_seen
         )
         self.assertEqual("TestVPN", address.anonymizer.provider_name)
+
+        # Test anonymizer.residential attribute
+        self.assertEqual(82, address.anonymizer.residential.confidence)
+        self.assertEqual(
+            datetime.date(2026, 5, 11),
+            address.anonymizer.residential.network_last_seen,
+        )
+        self.assertEqual("quickshift", address.anonymizer.residential.provider_name)
 
         self.assertEqual("ANONYMOUS_IP", address.risk_reasons[0].code)
         self.assertEqual(

--- a/tests/test_webservice.py
+++ b/tests/test_webservice.py
@@ -236,6 +236,14 @@ class BaseTransactionTest(BaseTest):
             self.assertEqual("310", model.ip_address.traits.mobile_country_code)
             self.assertEqual("004", model.ip_address.traits.mobile_network_code)
             self.assertEqual("ANONYMOUS_IP", model.ip_address.risk_reasons[0].code)
+            self.assertEqual(
+                82,
+                model.ip_address.anonymizer.residential.confidence,
+            )
+            self.assertEqual(
+                "quickshift",
+                model.ip_address.anonymizer.residential.provider_name,
+            )
 
     def test_authorization_header(self) -> None:
         # Credentials must be sent via the Authorization header rather than the


### PR DESCRIPTION
## Summary

Surfaces the new `residential` sub-object of the `anonymizer` object in the minFraud Insights and Factors `ip_address` response. The models reuse the GeoIP2 library's Anonymizer record, so this is a fixtures/tests/changelog change; the field flows through via the dependency.

Depends on maxmind/GeoIP2-python#440. At release time the `geoip2` requirement must be bumped to `>=5.3.0` once that version is on PyPI.

## Testing

With geoip2 built from that PR: pytest 246 passed; ruff check, ruff format --check, and mypy clean. Against released geoip2 5.2.0 the new assertions fail as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)