### PR TITLE
Update description for risk reason multiplier (DAT-7343)

### DIFF
--- a/src/minfraud/models.py
+++ b/src/minfraud/models.py
@@ -910,8 +910,8 @@ class RiskScoreReason(_Serializable):
     multiplier: float
     """The factor by which the risk score is increased (if the value is greater than 1)
     or decreased (if the value is less than 1) for given risk reason(s).
-    Multipliers greater than 1.5 and less than 0.66 are considered significant
-    and lead to risk reason(s) being present."""
+    Multipliers representing a significant percentage increase or decrease in
+    the risk score lead to risk reason(s) being present."""
 
     reasons: list[Reason]
     """This list contains :class:`.Reason` objects that describe


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that risk reasons apply when they indicate significant percentage increases or decreases, replacing references to fixed thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->